### PR TITLE
Fixing move voted out player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Change Log
 
-## v0.2.0
+## v0.2.1
+### Bugs
+- Players always get moved to the dead channel when voted out.
+- Nil pointer dereference bug fixed.
+- Fixed certificate commands in README.
 
+
+## v0.2.0
 ### Changes
 - Updated README to include setup instructions.
 
 ### New Features
-- Allow passing botname, cert, key, server as parameters.
+- Allow passing botname, cert, key, server as parameters from config file.
 
 
 ## v0.1.0

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Once the bot and capture are running, players need to join the lobby channel and
 
 ## Certificate Help
 
-Export your bot's certificate from mumble. This should be in a p12/pkcs format. Now convert this to a pem format with the following commands:
+Export your bot's certificate from mumble (See this [video](https://www.typefrag.com/mumble/tutorials/backup-or-import-certificate/) for help). This should be in a p12/pkcs format. Now convert this to a pem format with the following commands:
 ```
-openssl pkcs12 -in botuser.p12 -nocerts -out botuser.key
-openssl pkcs12 -in botuser.p12 -nocerts -nokeys -out botuser.crt
+openssl pkcs12 -info -in botuser.p12 -nodes -out 6ix9ine.key -nocerts
+openssl pkcs12 -info -in botuser.p12 -nodes -out botuser.crt -nokeys
 ```
 
 ## Config Example

--- a/mumble/mumble.go
+++ b/mumble/mumble.go
@@ -28,14 +28,20 @@ func Kill(c *gumble.Client, player string, gamestate string, deadplayers []strin
 			duplicateplayer = duplicateplayer + 1
 		}
 	}
-	if duplicateplayer == 0 {
-		deadplayers = append(deadplayers, strings.TrimSpace(player2))
-		log.Println(player2, "is now dead")
+
+	if player2 != "" {
+		if duplicateplayer == 0 {
+			log.Println(player2, "is now dead")
+			deadplayers = append(deadplayers, strings.TrimSpace(player2))
+		} else {
+			log.Println(player2, "is already dead")
+		}
 	} else {
-		log.Println(player2, "is already dead")
+		log.Println("Ignoring blank player name")
 	}
 
 	log.Println("Dead Players:", deadplayers)
+
 	return deadplayers
 }
 


### PR DESCRIPTION
When player is already dead but not in the alive channel, ignoring the 'blank' player that gets generated